### PR TITLE
Fix issue #1: interact with network through any peer

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"time"
 
 	"github.com/pc-1827/distributed-file-system/p2p"
@@ -20,6 +21,7 @@ func makeServer(listenAddress string) *FileServer {
 	tcpTransport := p2p.NewTCPTransport(tcpTransportOptions)
 
 	FileServerOptions := FileServerOptions{
+		ID:                "ed771b97431d745fad6be935371ad1dbbd64a1487d1abdfb89563f2e454a8e28",
 		EncKey:            newEncryptionKey(),
 		StorageRoot:       listenAddress + "_network",
 		PathTransformFunc: CASPathTransformFunc,
@@ -54,43 +56,49 @@ func main() {
 
 	server3.Add("127.0.0.1:3000")
 	time.Sleep(500 * time.Millisecond)
-	server3.Add("127.0.0.1:4000")
+	server1.Add("127.0.0.1:4000")
 	time.Sleep(500 * time.Millisecond)
 	server2.Add("127.0.0.1:6000")
 
-	for i := 0; i < 1; i++ {
-		key := fmt.Sprintf("random_picture_%d.jpeg", i)
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("random_picture_%d1.jpeg", i)
+		key2 := fmt.Sprintf("random_picture_%d.jpeg", i)
 		data_string := "random_bullshit"
 		for i := 0; i < 1; i++ {
 			data_string = data_string + fmt.Sprintf("abcdefghijklmnopqrstuvwxyz_%d_random_bullshit", i)
 		}
 		data := bytes.NewReader([]byte(data_string))
 
-		// filePath := "test_files/big-file"
-		// file, err := os.Open(filePath)
-		// if err != nil {
-		// 	log.Fatal(err)
-		// }
-		// defer file.Close()
+		filePath := "test_files/Happy Life FREDJI (No Copyright Music).mp3"
+		file, err := os.Open(filePath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer file.Close()
 
 		// key := "test-6.png"
-		server3.Store(key, data)
+		server3.Store(key, file)
 		time.Sleep(5 * time.Millisecond)
-		server4.Store("random_key", bytes.NewReader([]byte("Another_random_bullshit")))
+		server4.Store(key2, data)
 		time.Sleep(5 * time.Millisecond)
 
-		if err := server1.store.Delete(server1.ID, key); err != nil {
+		if err := server2.store.Delete(server2.ID, key); err != nil {
 			log.Fatal(err)
 		}
 
-		r, err := server1.Get(key)
+		_, err = server2.Get(key)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		// if err := server3.Remove(key); err != nil {
-		// 	log.Fatal(err)
-		// }
+		r, err := server1.Get(key2)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err := server3.Remove(key); err != nil {
+			log.Fatal(err)
+		}
 
 		b, err := io.ReadAll(r)
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -97,6 +97,7 @@ type MessageGetFile struct {
 // binary data, decrypts and writes it to the local disk, and returns a reader to
 // that received file.
 func (s *FileServer) Get(key string) (io.Reader, error) {
+	fmt.Printf("[%s] MSG.ID: (%s), MSG.Key: (%s)\n", s.Transport.Addr(), s.ID, key)
 	if s.store.Has(s.ID, key) {
 		fmt.Printf("[%s] serving file (%s) from the local disk\n", s.Transport.Addr(), key)
 		_, r, err := s.store.Read(s.ID, key)
@@ -108,7 +109,7 @@ func (s *FileServer) Get(key string) (io.Reader, error) {
 	msg := Message{
 		Payload: MessageGetFile{
 			ID:  s.ID,
-			Key: hashKey(key),
+			Key: key,
 		},
 	}
 
@@ -158,7 +159,7 @@ func (s *FileServer) Store(key string, r io.Reader) error {
 	msg := Message{
 		Payload: MessageStoreFile{
 			ID:   s.ID,
-			Key:  hashKey(key),
+			Key:  key,
 			Size: size + 16,
 		},
 	}
@@ -196,7 +197,7 @@ func (s *FileServer) Remove(key string) error {
 	msg := Message{
 		Payload: MessageDeleteFile{
 			ID:  s.ID,
-			Key: hashKey(key),
+			Key: key,
 		},
 	}
 
@@ -318,6 +319,7 @@ func (s *FileServer) handleMessage(from string, msg *Message) error {
 // Checks if the requested file is present or not. If present reads the file,
 // and writes the encrypted binary data to the peer message was sent from.
 func (s *FileServer) handleMessageGetFile(from string, msg MessageGetFile) error {
+	fmt.Printf("[%s] MSG.ID: (%s), MSG.Key: (%s)\n", s.Transport.Addr(), msg.ID, msg.Key)
 	if !s.store.Has(msg.ID, msg.Key) {
 		return fmt.Errorf("[%s] file (%s) is not present in the disk", s.Transport.Addr(), msg.Key)
 	}


### PR DESCRIPTION
Changed the FileServerOptions so that every fileServer(peer) has the same encryption key will be replaced by token in future. Every peer uses the same key which allow all peer to store, fetch and remove any file in the network.